### PR TITLE
Fix relative attention scaling bug and config attr

### DIFF
--- a/attention/relative_attention.py
+++ b/attention/relative_attention.py
@@ -57,7 +57,7 @@ class RelativeMultiHeadSelfAttention(nn.Module):
         qk_r = torch.matmul(q_r, rel_k.transpose(-2, -1)).squeeze(-2)       # shape (batch_size, num_heads, seq_len, seq_len)
 
         qk = qk + qk_r
-        qk_r = qk / math.sqrt(self.head_dim)
+        qk = qk / math.sqrt(self.head_dim)
         probs = torch.softmax(qk, dim=-1)                                  # shape (batch_size, num_heads, seq_len, seq_len)
 
         attn = torch.matmul(probs, v) # scores torch.Size([2, 4, 12, 4])          

--- a/utils/config.py
+++ b/utils/config.py
@@ -57,6 +57,7 @@ class TrainingConfig:
         self.batch_size = batch_size
         self.learning_rate = learning_rate
         self.weight_decay = weight_decay
+        self.block_size = block_size
 
 class MLAConfig(Config):
     """Configuration class for MLA (Multi-Linear Attention) model.


### PR DESCRIPTION
## Summary
- fix scaling in `RelativeMultiHeadSelfAttention`
- expose `block_size` parameter in `TrainingConfig`

## Testing
- `python -m py_compile attention/*.py models/roformer/*.py utils/*.py`