### PR TITLE
Update single GPU training instruction

### DIFF
--- a/models/roformer/README.md
+++ b/models/roformer/README.md
@@ -15,7 +15,7 @@ The RoFormer model enhances the standard Transformer architecture by replacing t
 
 For single GPU training, you can use the provided Jupyter notebook:
 ```bash
-jupyter notebook roformer_training_single_gpu.ipynb
+jupyter notebook roformer_train_single_gpu.ipynb
 ```
 
 ### Multi-GPU Training with Accelerate


### PR DESCRIPTION
## Summary
- fix README for RoFormer single GPU training command

## Testing
- `pytest -q` *(fails: command not found)*