### PR TITLE
Add RMSNorm gradient notebook

### DIFF
--- a/norm/rmsnorm.ipynb
+++ b/norm/rmsnorm.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RMSNorm Gradient Derivation\n",
+    "\n",
+    "Equation 9 of \"Root Mean Square Layer Normalization\" gives the gradient of RMSNorm with respect to the input $x$:\n",
+    "\n",
+    "$$\\frac{\\partial \\mathcal{L}}{\\partial x_i}=\\frac{\\partial \\mathcal{L}}{\\partial y_i}\\frac{w_i}{r}-\\frac{w_i x_i}{n r^3}\\sum_j\\frac{\\partial \\mathcal{L}}{\\partial y_j}x_j,$$\n",
+    "\n",
+    "where $r=\\sqrt{\\frac{1}{n}\\sum_j x_j^2+\\epsilon}$. This notebook implements this formula and checks it against autograd."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "def rmsnorm_forward(x, weight, eps=1e-8):\n",
+    "    rms = torch.sqrt(x.pow(2).mean(-1, keepdim=True) + eps)\n",
+    "    return weight * x / rms\n",
+    "\n",
+    "# Example input\n",
+    "d = 4\n",
+    "x = torch.randn(2, d, requires_grad=True)\n",
+    "weight = torch.ones(d, requires_grad=True)\n",
+    "\n",
+    "y = rmsnorm_forward(x, weight)\n",
+    "loss = y.sum()\n",
+    "loss.backward()\n",
+    "print('Autograd grad:', x.grad)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Manual gradient based on Eq. 9\n",
+    "\n",
+    "def rmsnorm_backward(dy, x, weight, eps=1e-8):\n",
+    "    n = x.shape[-1]\n",
+    "    rms = torch.sqrt(x.pow(2).mean(-1, keepdim=True) + eps)\n",
+    "    dot = (dy * x).sum(-1, keepdim=True)\n",
+    "    dx = (dy * weight) / rms - (weight * x / (n * rms.pow(3))) * dot\n",
+    "    return dx\n",
+    "\n",
+    "# Verify against autograd\n",
+    "x.grad.zero_()\n",
+    "loss = rmsnorm_forward(x, weight).sum()\n",
+    "loss.backward()\n",
+    "manual_dx = rmsnorm_backward(torch.ones_like(y), x.detach(), weight.detach())\n",
+    "print('Manual grad:', manual_dx)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- create `norm` folder
- add `rmsnorm.ipynb` to show how to manually compute the gradient for RMSNorm (eq.9 in the paper)
- clarify the gradient calculation to match the equation

## Testing
- `pytest -q`
