### PR TITLE
Add basic tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+import unittest
+import importlib.util
+import os
+
+# Load Config from utils/config.py without importing utils package
+spec = importlib.util.spec_from_file_location(
+    "config", os.path.join(os.path.dirname(__file__), "..", "utils", "config.py")
+)
+config_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(config_mod)
+Config = config_mod.Config
+
+
+class ConfigTest(unittest.TestCase):
+    def test_config_defaults(self):
+        cfg = Config(vocab_size=10, d_model=32, num_heads=4)
+        self.assertEqual(cfg.per_head_dim, 8)
+        self.assertEqual(cfg.ffn_dim, 32)
+        self.assertEqual(cfg.vocab_size, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roformer_cpu.py
+++ b/tests/test_roformer_cpu.py
@@ -1,0 +1,22 @@
+import unittest
+
+try:
+    import torch
+    from utils.config import Config
+    from models.roformer.roformer import RoFormerDecoderLayer
+except ModuleNotFoundError:
+    torch = None
+
+
+class RoformerCpuTest(unittest.TestCase):
+    @unittest.skipIf(torch is None, "torch is not installed")
+    def test_decoder_layer_cpu_raises(self):
+        config = Config(vocab_size=100, d_model=16, num_heads=4, num_layers=1)
+        layer = RoFormerDecoderLayer(config)
+        x = torch.randn(1, 1, 16)
+        with self.assertRaises(RuntimeError):
+            layer(x)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -1,0 +1,29 @@
+import unittest
+
+try:
+    import torch
+    from utils.rope import apply_rope
+except ModuleNotFoundError:
+    torch = None
+
+
+class RopeTest(unittest.TestCase):
+    @unittest.skipIf(torch is None, "torch is not installed")
+    def test_apply_rope_shape(self):
+        x = torch.randn(2, 2, 3, 4)
+        out = apply_rope(x, past_seq_len=0, visualize=False)
+        self.assertEqual(out.shape, x.shape)
+
+    @unittest.skipIf(torch is None, "torch is not installed")
+    def test_apply_rope_rotation_simple(self):
+        x = torch.zeros(1, 1, 1, 4)
+        x[..., 0] = 1.0
+        x[..., 1] = 0.0
+        x[..., 2] = 0.0
+        x[..., 3] = 1.0
+        out = apply_rope(x, past_seq_len=0, freq=1.0, visualize=False)
+        torch.testing.assert_close(out, x)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a minimal unit test suite
- skip rope and RoFormer tests if torch isn't installed

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_682ba98a6d048332ba0ce73e03b6aad4